### PR TITLE
Allow a grid with only 1 row

### DIFF
--- a/src/fancy/Grid.hx
+++ b/src/fancy/Grid.hx
@@ -165,6 +165,7 @@ class Grid {
     rightRailSize = fixedRight == 0 ? 0 : (contentWidth - hOffset(columns - fixedRight));
     grid9.resizeContent(contentWidth, contentHeight);
     grid9.sizeRails(topRailSize, bottomRailSize, leftRailSize, rightRailSize);
+    grid9.setPosition(grid9.position.x, grid9.position.y);
 
     renderCorners();
     renderMiddle(grid9.position.y);
@@ -362,7 +363,7 @@ class Grid {
   }
 
   function renderMiddle(v: Float) {
-    var r = Search.binary(0, rows, rowComparator(v + topRailSize)).max(fixedTop);
+    var r = Search.binary(0, rows - 1, rowComparator(v + topRailSize)).max(fixedTop);
     var top = vOffset(r);
     var limit = top + vSize(r) + grid9.gridMiddleHeight;
 
@@ -391,7 +392,7 @@ class Grid {
   }
 
   function renderCenter(v: Float) {
-    var c = Search.binary(0, columns, columnComparator(v + leftRailSize)).max(fixedLeft);
+    var c = Search.binary(0, columns - 1, columnComparator(v + leftRailSize)).max(fixedLeft);
     var left = hOffset(c);
     var limit = left + hSize(c) + grid9.gridCenterWidth;
 
@@ -419,8 +420,8 @@ class Grid {
   }
 
   function renderMain(x: Float, y: Float) {
-    var r = Search.binary(0, rows, rowComparator(y + topRailSize)).max(fixedTop);
-    var c = Search.binary(0, columns, columnComparator(x + leftRailSize)).max(fixedLeft);
+    var r = Search.binary(0, rows - 1, rowComparator(y + topRailSize)).max(fixedTop);
+    var c = Search.binary(0, columns - 1, columnComparator(x + leftRailSize)).max(fixedLeft);
 
     var left = hOffset(c);
     var top = vOffset(r);

--- a/src/fancy/Grid.hx
+++ b/src/fancy/Grid.hx
@@ -12,6 +12,25 @@ using thx.Floats;
 using thx.Ints;
 using thx.Iterators;
 
+enum VerticalScrollPosition {
+  Top;
+  Bottom;
+  FromTop(distance: ScrollUnit);
+  FromBottom(distance: ScrollUnit);
+}
+
+enum HorizontalScrollPosition {
+  Left;
+  Right;
+  FromLeft(distance: ScrollUnit);
+  FromRight(distance: ScrollUnit);
+}
+
+enum ScrollUnit {
+  Pixels(value: Float);
+  Cells(value: Int);
+}
+
 enum CellDimension {
   Fixed(v: Float);
   RenderFirst;
@@ -157,6 +176,48 @@ class Grid {
     renderCenter(grid9.position.x);
     renderMain(grid9.position.x, grid9.position.y);
     grid9.refresh();
+  }
+
+  public function scrollTo(?x: HorizontalScrollPosition, ?y: VerticalScrollPosition) {
+    var xPos = x == null ? grid9.position.x : resolveHorizontalScroll(x),
+        yPos = y == null ? grid9.position.y : resolveVerticalScroll(y);
+
+    // `setPosition` in Grid9 already handles limits and early returns if
+    // nothing changed, so we can just go ahead and call it here
+    grid9.setPosition(xPos, yPos);
+    grid9.refresh();
+  }
+
+  function resolveHorizontalDistance(x: ScrollUnit): Float {
+    return switch x {
+      case Pixels(v): v;
+      case Cells(v): hOffset(v);
+    };
+  }
+
+  function resolveHorizontalScroll(x: HorizontalScrollPosition): Float {
+    return switch x {
+      case Left: 0;
+      case Right: grid9.contentWidth; // grid9.setPosition will limit this
+      case FromLeft(d): resolveHorizontalDistance(d);
+      case FromRight(d): grid9.contentWidth - resolveHorizontalDistance(d);
+    };
+  }
+
+  function resolveVerticalDistance(y: ScrollUnit): Float {
+    return switch y {
+      case Pixels(v): v;
+      case Cells(v): vOffset(v);
+    };
+  }
+
+  function resolveVerticalScroll(y: VerticalScrollPosition): Float {
+    return switch y {
+      case Top: 0;
+      case Bottom: grid9.contentHeight;
+      case FromTop(d): resolveVerticalDistance(d);
+      case FromBottom(d): grid9.contentHeight - resolveVerticalDistance(d);
+    };
   }
 
   function invalidateCache() {

--- a/src/fancy/Grid.hx
+++ b/src/fancy/Grid.hx
@@ -147,10 +147,23 @@ class Grid {
     this.rows = rows;
     this.columns = columns;
     invalidateCache();
+
+    // recalculate sizes with the new content, and update grid9
+    var contentWidth = hOffset(columns - 1) + hSize(columns - 1);
+    var contentHeight = vOffset(rows - 1) + vSize(rows - 1);
+
+    topRailSize = vOffset(fixedTop);
+    leftRailSize = hOffset(fixedLeft);
+    bottomRailSize = fixedBottom == 0 ? 0 : (contentHeight - vOffset(rows - fixedBottom));
+    rightRailSize = fixedRight == 0 ? 0 : (contentWidth - hOffset(columns - fixedRight));
+    grid9.resizeContent(contentWidth, contentHeight);
+    grid9.sizeRails(topRailSize, bottomRailSize, leftRailSize, rightRailSize);
+
     renderCorners();
     renderMiddle(grid9.position.y);
     renderCenter(grid9.position.x);
     renderMain(grid9.position.x, grid9.position.y);
+    grid9.refresh();
   }
 
   function invalidateCache() {

--- a/src/fancy/Grid.hx
+++ b/src/fancy/Grid.hx
@@ -88,8 +88,8 @@ class Grid {
     render = options.render;
     vOffset = assignVOffset(options.vOffset);
     hOffset = assignHOffset(options.hOffset);
-    vSize = assignVSize(options.vSize != null ? options.vSize : function (_) return RenderSmart);
     hSize = assignHSize(options.hSize != null ? options.hSize : function (_) return RenderSmart);
+    vSize = assignVSize(options.vSize != null ? options.vSize : function (_) return RenderSmart);
     rows = options.rows;
     columns = options.columns;
 
@@ -195,16 +195,14 @@ class Grid {
           var els: Array<Element> = [], el;
           var leftBound = (fixedLeft + 1).max(2).min(columns);
           for(i in 0...leftBound) {
-            el = renderAt(row, i);
+            el = renderWithWidth(view, row, i);
             els.push(el);
-            view.append(el);
           }
           // test last content cell and right shoulder
           var rightBound = (columns - fixedRight - 1).max(leftBound + 1);
           for(i in rightBound...columns) {
-            el = renderAt(row, i);
+            el = renderWithWidth(view, row, i);
             els.push(el);
-            view.append(el);
           }
           // get measure
           for(el in els)
@@ -215,8 +213,7 @@ class Grid {
           v;
         case RenderFirst:
           // test left shoulder and first content cell
-          var el = renderAt(row, 0);
-          view.append(el);
+          var el = renderWithWidth(view, row, 0);
 
           // get measure
           v = v.max(el.getOuterHeight());
@@ -225,10 +222,9 @@ class Grid {
         case RenderAll:
           var els = [], el;
           for (i in 0...columns) {
-            el = renderAt(row, i);
+            el = renderWithWidth(view, row, i);
 
             els.push(el);
-            view.append(el);
           }
 
           // get measure
@@ -359,6 +355,13 @@ class Grid {
     el.style.left = '${hOffset(col)}px';
     el.style.width = '${hSize(col)}px';
     el.style.height = '${vSize(row)}px';
+    return el;
+  }
+
+  function renderWithWidth(parent: Element, row: Int, col: Int) {
+    var el = renderAt(row, col);
+    parent.append(el);
+    el.style.width = '${hSize(col)}px';
     return el;
   }
 

--- a/src/fancy/Grid.hx
+++ b/src/fancy/Grid.hx
@@ -98,26 +98,14 @@ class Grid {
     fixedTop = options.fixedTop.or(0);
     fixedBottom = options.fixedBottom.or(0);
 
-    var contentWidth = hOffset(columns - 1) + hSize(columns - 1);
-    var contentHeight = vOffset(rows - 1) + vSize(rows - 1);
-
-    topRailSize = vOffset(fixedTop);
-    leftRailSize = hOffset(fixedLeft);
-    bottomRailSize = fixedBottom == 0 ? 0 : (contentHeight - vOffset(rows - fixedBottom));
-    rightRailSize = fixedRight == 0 ? 0 : (contentWidth - hOffset(columns - fixedRight));
-
     var scrollerSize = options.scrollerSize.or(10);
 
     grid9 = new Grid9(view, {
       scrollerMinSize : options.scrollerMinSize.or(scrollerSize),
       scrollerMaxSize : options.scrollerMaxSize,
       scrollerSize : scrollerSize,
-      contentWidth : contentWidth,
-      contentHeight : contentHeight,
-      topRail : topRailSize,
-      leftRail : leftRailSize,
-      bottomRail : bottomRailSize,
-      rightRail : rightRailSize,
+      contentWidth : 0,
+      contentHeight : 0,
       onScroll : function(x, y, ox, oy) {
         if(oy != y)
           renderMiddle(y);
@@ -144,13 +132,10 @@ class Grid {
     bottomCenter = grid9.bottomCenter;
     bottomRight = grid9.bottomRight;
 
-    renderCorners();
-    renderMiddle(0);
-    renderCenter(0);
-    renderMain(0, 0);
+    setRowsAndColumns(rows, columns);
   }
 
-  public function setRowsAndColumns(rows : Int, columns : Int) {
+  public function setRowsAndColumns(rows: Int, columns: Int) {
     this.rows = rows;
     this.columns = columns;
     invalidateCache();
@@ -163,8 +148,8 @@ class Grid {
     leftRailSize = hOffset(fixedLeft);
     bottomRailSize = fixedBottom == 0 ? 0 : (contentHeight - vOffset(rows - fixedBottom));
     rightRailSize = fixedRight == 0 ? 0 : (contentWidth - hOffset(columns - fixedRight));
-    grid9.resizeContent(contentWidth, contentHeight);
     grid9.sizeRails(topRailSize, bottomRailSize, leftRailSize, rightRailSize);
+    grid9.resizeContent(contentWidth, contentHeight);
     grid9.setPosition(grid9.position.x, grid9.position.y);
 
     renderCorners();

--- a/src/fancy/core/Grid9.hx
+++ b/src/fancy/core/Grid9.hx
@@ -157,14 +157,13 @@ class Grid9 {
     size = getGridSizeFromContainer();
     resizeGrid(size.w, size.h);
 
-    resizeContent(options.contentWidth, options.contentHeight);
     sizeRails(
       options.topRail.or(0),
       options.bottomRail.or(0),
       options.leftRail.or(0),
       options.rightRail.or(0)
     );
-    refresh();
+    resizeContent(options.contentWidth, options.contentHeight);
 
     // EVENTS
     // TODO make wiring optional
@@ -309,14 +308,13 @@ class Grid9 {
 
     top.style.width = bottom.style.width = '${gridWidth.min(contentWidth)}px';
     left.style.height = right.style.height = '${gridHeight.min(contentHeight)}px';
+    middles.each.fn(_.style.height = '${contentHeight - topRail - bottomRail}px');
+    centers.each.fn(_.style.width = '${contentWidth - leftRail - rightRail}px');
   }
 
   public function sizeRails(topRail: Float, bottomRail: Float, leftRail: Float, rightRail: Float) {
-    // FIXME: i commented out the early return because sometimes this function
-    // was the only way i could find to reset px width/height. i don't actually
-    // want to change the rails.
-    // if(this.topRail == topRail && this.bottomRail == bottomRail && this.leftRail == leftRail && this.rightRail == rightRail)
-    //   return;
+    if(this.topRail == topRail && this.bottomRail == bottomRail && this.leftRail == leftRail && this.rightRail == rightRail)
+      return;
     dirty = true;
     this.topRail = topRail;
     this.bottomRail = bottomRail;
@@ -324,12 +322,10 @@ class Grid9 {
     this.rightRail = rightRail;
     top.style.height = '${topRail}px';
     tops.each.fn(_.style.height = '${topRail}px');
-    middles.each.fn(_.style.height = '${contentHeight - topRail - bottomRail}px');
     bottom.style.height = '${bottomRail}px';
     bottoms.each.fn(_.style.height = '${bottomRail}px');
     left.style.width = '${leftRail}px';
     lefts.each.fn(_.style.width = '${leftRail}px');
-    centers.each.fn(_.style.width = '${contentWidth - leftRail - rightRail}px');
     right.style.width = '${rightRail}px';
     rights.each.fn(_.style.width = '${rightRail}px');
   }

--- a/src/fancy/core/Grid9.hx
+++ b/src/fancy/core/Grid9.hx
@@ -312,8 +312,11 @@ class Grid9 {
   }
 
   public function sizeRails(topRail: Float, bottomRail: Float, leftRail: Float, rightRail: Float) {
-    if(this.topRail == topRail && this.bottomRail == bottomRail && this.leftRail == leftRail && this.rightRail == rightRail)
-      return;
+    // FIXME: i commented out the early return because sometimes this function
+    // was the only way i could find to reset px width/height. i don't actually
+    // want to change the rails.
+    // if(this.topRail == topRail && this.bottomRail == bottomRail && this.leftRail == leftRail && this.rightRail == rightRail)
+    //   return;
     dirty = true;
     this.topRail = topRail;
     this.bottomRail = bottomRail;

--- a/src/fancy/core/Search.hx
+++ b/src/fancy/core/Search.hx
@@ -13,10 +13,10 @@ class Search {
       var c = comparator(m);
       if(c < 0) {
         l = m + 1;
-        return search(mid(l, r), l, r);
+        return l == r ? l : search(mid(l, r), l, r);
       } else if(c > 0) {
         r = m - 1;
-        return search(mid(l, r), l, r);
+        return r == l ? r : search(mid(l, r), l, r);
       } else {
         return m;
       }

--- a/src/fancy/core/SwipeMoveHelper.hx
+++ b/src/fancy/core/SwipeMoveHelper.hx
@@ -21,7 +21,8 @@ class SwipeMoveHelper {
       });
     });
     el.on("touchstart", function(e: js.html.TouchEvent) {
-      e.preventDefault();
+      // don't prevent default on touchstart/end because it stops mouse events
+      // like click from firing for this event
       if(null != id) return;
       var t = e.touches[0];
       id = t.identifier;
@@ -29,7 +30,6 @@ class SwipeMoveHelper {
       y = t.clientY;
     });
     el.on("touchend", function(e: js.html.TouchEvent) {
-      e.preventDefault();
       if(e.touches.length == 0) {
         this.id = null;
       } else {

--- a/test/fancy/core/TestSearch.hx
+++ b/test/fancy/core/TestSearch.hx
@@ -9,13 +9,17 @@ class TestSearch {
   public function comp(expected: Int)
     return function(v) return thx.Ints.compare(v, expected);
 
+  public function comp2(a: Int)
+    return -1;
+
   public function testBinarySearch() {
     var max = 10;
     var values = thx.Ints.range(0, max + 1);
-    trace(values);
     for(v in values)
       Assert.equals(v, binary(0, max, comp(v)));
 
     Assert.equals(3, binary(max, 0, comp(3)));
+
+    Assert.equals(3, binary(0, 3, comp2));
   }
 }

--- a/testbin/index.js
+++ b/testbin/index.js
@@ -1478,10 +1478,18 @@ fancy_core_Search.binary = function(min,max,comparator) {
 		var c = comparator(m);
 		if(c < 0) {
 			l1 = m + 1;
-			return search(mid(l1,r1),l1,r1);
+			if(l1 == r1) {
+				return l1;
+			} else {
+				return search(mid(l1,r1),l1,r1);
+			}
 		} else if(c > 0) {
 			r1 = m - 1;
-			return search(mid(l1,r1),l1,r1);
+			if(r1 == l1) {
+				return r1;
+			} else {
+				return search(mid(l1,r1),l1,r1);
+			}
 		} else {
 			return m;
 		}
@@ -1594,16 +1602,19 @@ fancy_core_TestSearch.prototype = {
 			return v - expected;
 		};
 	}
+	,comp2: function(a) {
+		return -1;
+	}
 	,testBinarySearch: function() {
 		var values = thx_Ints.range(0,11);
-		haxe_Log.trace(values,{ fileName : "TestSearch.hx", lineNumber : 15, className : "fancy.core.TestSearch", methodName : "testBinarySearch"});
 		var _g = 0;
 		while(_g < values.length) {
 			var v = values[_g];
 			++_g;
-			utest_Assert.equals(v,fancy_core_Search.binary(0,10,this.comp(v)),null,{ fileName : "TestSearch.hx", lineNumber : 17, className : "fancy.core.TestSearch", methodName : "testBinarySearch"});
+			utest_Assert.equals(v,fancy_core_Search.binary(0,10,this.comp(v)),null,{ fileName : "TestSearch.hx", lineNumber : 19, className : "fancy.core.TestSearch", methodName : "testBinarySearch"});
 		}
-		utest_Assert.equals(3,fancy_core_Search.binary(10,0,this.comp(3)),null,{ fileName : "TestSearch.hx", lineNumber : 19, className : "fancy.core.TestSearch", methodName : "testBinarySearch"});
+		utest_Assert.equals(3,fancy_core_Search.binary(10,0,this.comp(3)),null,{ fileName : "TestSearch.hx", lineNumber : 21, className : "fancy.core.TestSearch", methodName : "testBinarySearch"});
+		utest_Assert.equals(3,fancy_core_Search.binary(0,3,$bind(this,this.comp2)),null,{ fileName : "TestSearch.hx", lineNumber : 23, className : "fancy.core.TestSearch", methodName : "testBinarySearch"});
 	}
 	,__class__: fancy_core_TestSearch
 };
@@ -10679,23 +10690,23 @@ utest_Assert.isIterator = function(v,isAnonym) {
 		return false;
 	}
 };
-utest_Assert.sameAs = function(expected,value,status) {
+utest_Assert.sameAs = function(expected,value,status,approx) {
 	var texpected = utest_Assert.getTypeName(expected);
 	var tvalue = utest_Assert.getTypeName(value);
-	if(texpected != tvalue) {
+	if(texpected != tvalue && !(texpected == "Int" && tvalue == "Float" || texpected == "Float" && tvalue == "Int")) {
 		status.error = "expected type " + texpected + " but it is " + tvalue + (status.path == ""?"":" for field " + status.path);
 		return false;
 	}
 	var _g = Type["typeof"](expected);
 	switch(_g[1]) {
-	case 0:case 1:case 3:
+	case 0:case 3:
 		if(expected != value) {
 			status.error = "expected " + utest_Assert.q(expected) + " but it is " + utest_Assert.q(value) + (status.path == ""?"":" for field " + status.path);
 			return false;
 		}
 		return true;
-	case 2:
-		if(!utest_Assert._floatEquals(expected,value)) {
+	case 1:case 2:
+		if(!utest_Assert._floatEquals(expected,value,approx)) {
 			status.error = "expected " + utest_Assert.q(expected) + " but it is " + utest_Assert.q(value) + (status.path == ""?"":" for field " + status.path);
 			return false;
 		}
@@ -10719,7 +10730,7 @@ utest_Assert.sameAs = function(expected,value,status) {
 				if(Reflect.isFunction(e)) {
 					continue;
 				}
-				if(!utest_Assert.sameAs(e,Reflect.field(value,field),status)) {
+				if(!utest_Assert.sameAs(e,Reflect.field(value,field),status,approx)) {
 					return false;
 				}
 			}
@@ -10750,7 +10761,7 @@ utest_Assert.sameAs = function(expected,value,status) {
 				while(_g11 < _g2) {
 					var i = _g11++;
 					status.path = path1 == ""?"iterator[" + i + "]":path1 + "[" + i + "]";
-					if(!utest_Assert.sameAs(evalues[i],vvalues[i],status)) {
+					if(!utest_Assert.sameAs(evalues[i],vvalues[i],status,approx)) {
 						status.error = "expected " + utest_Assert.q(expected) + " but it is " + utest_Assert.q(value) + (status.path == ""?"":" for field " + status.path);
 						return false;
 					}
@@ -10776,7 +10787,7 @@ utest_Assert.sameAs = function(expected,value,status) {
 				while(_g12 < _g3) {
 					var i1 = _g12++;
 					status.path = path2 == ""?"iterable[" + i1 + "]":path2 + "[" + i1 + "]";
-					if(!utest_Assert.sameAs(evalues1[i1],vvalues1[i1],status)) {
+					if(!utest_Assert.sameAs(evalues1[i1],vvalues1[i1],status,approx)) {
 						return false;
 					}
 				}
@@ -10799,7 +10810,7 @@ utest_Assert.sameAs = function(expected,value,status) {
 			return false;
 		}
 		if(typeof(expected) == "string" && expected != value) {
-			status.error = "expected '" + Std.string(expected) + "' but it is '" + Std.string(value) + "'";
+			status.error = "expected string '" + Std.string(expected) + "' but it is '" + Std.string(value) + "'";
 			return false;
 		}
 		if((expected instanceof Array) && expected.__enum__ == null) {
@@ -10814,8 +10825,8 @@ utest_Assert.sameAs = function(expected,value,status) {
 				while(_g13 < _g4) {
 					var i2 = _g13++;
 					status.path = path3 == ""?"array[" + i2 + "]":path3 + "[" + i2 + "]";
-					if(!utest_Assert.sameAs(expected[i2],value[i2],status)) {
-						status.error = "expected " + utest_Assert.q(expected[i2]) + " but it is " + utest_Assert.q(value[i2]) + (status.path == ""?"":" for field " + status.path);
+					if(!utest_Assert.sameAs(expected[i2],value[i2],status,approx)) {
+						status.error = "expected array element at [" + i2 + "] to be " + utest_Assert.q(expected[i2]) + " but it is " + utest_Assert.q(value[i2]) + (status.path == ""?"":" for field " + status.path);
 						return false;
 					}
 				}
@@ -10870,7 +10881,7 @@ utest_Assert.sameAs = function(expected,value,status) {
 					var key = keys[_g21];
 					++_g21;
 					status.path = path4 == ""?"hash[" + Std.string(key) + "]":path4 + "[" + Std.string(key) + "]";
-					if(!utest_Assert.sameAs(map.get(key),vmap.get(key),status)) {
+					if(!utest_Assert.sameAs(map.get(key),vmap.get(key),status,approx)) {
 						status.error = "expected " + utest_Assert.q(expected) + " but it is " + utest_Assert.q(value) + (status.path == ""?"":" for field " + status.path);
 						return false;
 					}
@@ -10896,7 +10907,7 @@ utest_Assert.sameAs = function(expected,value,status) {
 				while(_g16 < _g7) {
 					var i4 = _g16++;
 					status.path = path5 == ""?"iterator[" + i4 + "]":path5 + "[" + i4 + "]";
-					if(!utest_Assert.sameAs(evalues2[i4],vvalues2[i4],status)) {
+					if(!utest_Assert.sameAs(evalues2[i4],vvalues2[i4],status,approx)) {
 						status.error = "expected " + utest_Assert.q(expected) + " but it is " + utest_Assert.q(value) + (status.path == ""?"":" for field " + status.path);
 						return false;
 					}
@@ -10918,7 +10929,7 @@ utest_Assert.sameAs = function(expected,value,status) {
 				while(_g17 < _g8) {
 					var i5 = _g17++;
 					status.path = path6 == ""?"iterable[" + i5 + "]":path6 + "[" + i5 + "]";
-					if(!utest_Assert.sameAs(evalues3[i5],vvalues3[i5],status)) {
+					if(!utest_Assert.sameAs(evalues3[i5],vvalues3[i5],status,approx)) {
 						return false;
 					}
 				}
@@ -10938,7 +10949,7 @@ utest_Assert.sameAs = function(expected,value,status) {
 				if(Reflect.isFunction(e1)) {
 					continue;
 				}
-				if(!utest_Assert.sameAs(e1,Reflect.field(value,field1),status)) {
+				if(!utest_Assert.sameAs(e1,Reflect.field(value,field1),status,approx)) {
 					return false;
 				}
 			}
@@ -10953,7 +10964,7 @@ utest_Assert.sameAs = function(expected,value,status) {
 		}
 		if(status.recursive || status.path == "") {
 			if(expected[1] != value[1]) {
-				status.error = "expected " + utest_Assert.q(expected[0]) + " but it is " + utest_Assert.q(value[0]) + (status.path == ""?"":" for field " + status.path);
+				status.error = "expected enum constructor " + utest_Assert.q(expected[0]) + " but it is " + utest_Assert.q(value[0]) + (status.path == ""?"":" for field " + status.path);
 				return false;
 			}
 			var eparams = expected.slice(2);
@@ -10964,8 +10975,8 @@ utest_Assert.sameAs = function(expected,value,status) {
 			while(_g18 < _g10) {
 				var i6 = _g18++;
 				status.path = path8 == ""?"enum[" + i6 + "]":path8 + "[" + i6 + "]";
-				if(!utest_Assert.sameAs(eparams[i6],vparams[i6],status)) {
-					status.error = "expected " + utest_Assert.q(expected) + " but it is " + utest_Assert.q(value) + (status.path == ""?"":" for field " + status.path);
+				if(!utest_Assert.sameAs(eparams[i6],vparams[i6],status,approx)) {
+					status.error = "expected enum param " + utest_Assert.q(expected) + " but it is " + utest_Assert.q(value) + (status.path == ""?"":" for field " + status.path) + " with " + status.error;
 					return false;
 				}
 			}
@@ -10983,9 +10994,12 @@ utest_Assert.q = function(v) {
 		return Std.string(v);
 	}
 };
-utest_Assert.same = function(expected,value,recursive,msg,pos) {
+utest_Assert.same = function(expected,value,recursive,msg,approx,pos) {
+	if(null == approx) {
+		approx = 1e-5;
+	}
 	var status = { recursive : null == recursive?true:recursive, path : "", error : null};
-	if(utest_Assert.sameAs(expected,value,status)) {
+	if(utest_Assert.sameAs(expected,value,status,approx)) {
 		utest_Assert.pass(msg,pos);
 	} else {
 		utest_Assert.fail(msg == null?status.error:msg,pos);
@@ -11256,11 +11270,14 @@ utest_Notifier.prototype = {
 	,__class__: utest_Notifier
 };
 var utest_Runner = function() {
+	this.globalPattern = null;
 	this.fixtures = [];
 	this.onProgress = new utest_Dispatcher();
 	this.onStart = new utest_Dispatcher();
 	this.onComplete = new utest_Dispatcher();
 	this.onPrecheck = new utest_Dispatcher();
+	this.onTestStart = new utest_Dispatcher();
+	this.onTestComplete = new utest_Dispatcher();
 	this.length = 0;
 };
 $hxClasses["utest.Runner"] = utest_Runner;
@@ -11271,8 +11288,17 @@ utest_Runner.prototype = {
 	,onStart: null
 	,onComplete: null
 	,onPrecheck: null
+	,onTestStart: null
+	,onTestComplete: null
 	,length: null
-	,addCase: function(test,setup,teardown,prefix,pattern) {
+	,globalPattern: null
+	,addCase: function(test,setup,teardown,prefix,pattern,setupAsync,teardownAsync) {
+		if(teardownAsync == null) {
+			teardownAsync = "teardownAsync";
+		}
+		if(setupAsync == null) {
+			setupAsync = "setupAsync";
+		}
 		if(prefix == null) {
 			prefix = "test";
 		}
@@ -11288,11 +11314,17 @@ utest_Runner.prototype = {
 		if(!this.isMethod(test,setup)) {
 			setup = null;
 		}
+		if(!this.isMethod(test,setupAsync)) {
+			setupAsync = null;
+		}
 		if(!this.isMethod(test,teardown)) {
 			teardown = null;
 		}
+		if(!this.isMethod(test,teardownAsync)) {
+			teardownAsync = null;
+		}
 		var fields = Type.getInstanceFields(test == null?null:js_Boot.getClass(test));
-		if(pattern == null) {
+		if(this.globalPattern == null && pattern == null) {
 			var _g = 0;
 			while(_g < fields.length) {
 				var field = fields[_g];
@@ -11303,9 +11335,14 @@ utest_Runner.prototype = {
 				if(!this.isMethod(test,field)) {
 					continue;
 				}
-				this.addFixture(new utest_TestFixture(test,field,setup,teardown));
+				this.addFixture(new utest_TestFixture(test,field,setup,teardown,setupAsync,teardownAsync));
 			}
 		} else {
+			if(this.globalPattern != null) {
+				pattern = this.globalPattern;
+			} else {
+				pattern = pattern;
+			}
 			var _g1 = 0;
 			while(_g1 < fields.length) {
 				var field1 = fields[_g1];
@@ -11316,7 +11353,7 @@ utest_Runner.prototype = {
 				if(!this.isMethod(test,field1)) {
 					continue;
 				}
-				this.addFixture(new utest_TestFixture(test,field1,setup,teardown));
+				this.addFixture(new utest_TestFixture(test,field1,setup,teardown,setupAsync,teardownAsync));
 			}
 		}
 	}
@@ -11352,19 +11389,23 @@ utest_Runner.prototype = {
 		var handler = new utest_TestHandler(fixture);
 		handler.onComplete.add($bind(this,this.testComplete));
 		handler.onPrecheck.add(($_=this.onPrecheck,$bind($_,$_.dispatch)));
+		this.onTestStart.dispatch(handler);
 		handler.execute();
 	}
 	,testComplete: function(h) {
+		this.onTestComplete.dispatch(h);
 		this.onProgress.dispatch({ result : utest_TestResult.ofHandler(h), done : this.pos, totals : this.length});
 		this.runNext();
 	}
 	,__class__: utest_Runner
 };
-var utest_TestFixture = function(target,method,setup,teardown) {
+var utest_TestFixture = function(target,method,setup,teardown,setupAsync,teardownAsync) {
 	this.target = target;
 	this.method = method;
 	this.setup = setup;
+	this.setupAsync = setupAsync;
 	this.teardown = teardown;
+	this.teardownAsync = teardownAsync;
 };
 $hxClasses["utest.TestFixture"] = utest_TestFixture;
 utest_TestFixture.__name__ = ["utest","TestFixture"];
@@ -11372,7 +11413,9 @@ utest_TestFixture.prototype = {
 	target: null
 	,method: null
 	,setup: null
+	,setupAsync: null
 	,teardown: null
+	,teardownAsync: null
 	,checkMethod: function(name,arg) {
 		var field = Reflect.field(this.target,name);
 		if(field == null) {
@@ -11418,18 +11461,28 @@ utest_TestHandler.prototype = {
 	,execute: function() {
 		try {
 			this.executeMethod(this.fixture.setup);
-			try {
-				this.executeMethod(this.fixture.method);
-			} catch( e ) {
-				haxe_CallStack.lastException = e;
-				if (e instanceof js__$Boot_HaxeError) e = e.val;
-				this.results.add(utest_Assertation.Error(e,utest_TestHandler.exceptionStack()));
-			}
-		} catch( e1 ) {
-			haxe_CallStack.lastException = e1;
-			if (e1 instanceof js__$Boot_HaxeError) e1 = e1.val;
-			this.results.add(utest_Assertation.SetupError(e1,utest_TestHandler.exceptionStack()));
+			var f = $bind(this,this.executeAsync);
+			this.executeAsyncMethod(this.fixture.setupAsync,function() {
+				f();
+			});
+		} catch( e ) {
+			haxe_CallStack.lastException = e;
+			if (e instanceof js__$Boot_HaxeError) e = e.val;
+			this.results.add(utest_Assertation.SetupError(e,utest_TestHandler.exceptionStack()));
+			this.executeFinally();
 		}
+	}
+	,executeAsync: function() {
+		try {
+			this.executeMethod(this.fixture.method);
+		} catch( e ) {
+			haxe_CallStack.lastException = e;
+			if (e instanceof js__$Boot_HaxeError) e = e.val;
+			this.results.add(utest_Assertation.Error(e,utest_TestHandler.exceptionStack()));
+		}
+		this.executeFinally();
+	}
+	,executeFinally: function() {
 		this.onPrecheck.dispatch(this);
 		this.checkTested();
 	}
@@ -11518,6 +11571,14 @@ utest_TestHandler.prototype = {
 		this.bindHandler();
 		Reflect.field(this.fixture.target,name).apply(this.fixture.target,[]);
 	}
+	,executeAsyncMethod: function(name,done) {
+		if(name == null) {
+			done();
+			return;
+		}
+		this.bindHandler();
+		Reflect.field(this.fixture.target,name).apply(this.fixture.target,[done]);
+	}
 	,tested: function() {
 		if(this.results.length == 0) {
 			this.results.add(utest_Assertation.Warning("no assertions"));
@@ -11533,11 +11594,18 @@ utest_TestHandler.prototype = {
 	,completed: function() {
 		try {
 			this.executeMethod(this.fixture.teardown);
+			var f = $bind(this,this.completedFinally);
+			this.executeAsyncMethod(this.fixture.teardownAsync,function() {
+				f();
+			});
 		} catch( e ) {
 			haxe_CallStack.lastException = e;
 			if (e instanceof js__$Boot_HaxeError) e = e.val;
 			this.results.add(utest_Assertation.TeardownError(e,utest_TestHandler.exceptionStack(2)));
+			this.completedFinally();
 		}
+	}
+	,completedFinally: function() {
 		this.unbindHandler();
 		this.onComplete.dispatch(this);
 	}
@@ -11555,7 +11623,9 @@ utest_TestResult.ofHandler = function(handler) {
 	r.pack = path.join(".");
 	r.method = handler.fixture.method;
 	r.setup = handler.fixture.setup;
+	r.setupAsync = handler.fixture.setupAsync;
 	r.teardown = handler.fixture.teardown;
+	r.teardownAsync = handler.fixture.teardownAsync;
 	r.assertations = handler.results;
 	return r;
 };
@@ -11564,7 +11634,9 @@ utest_TestResult.prototype = {
 	,cls: null
 	,method: null
 	,setup: null
+	,setupAsync: null
 	,teardown: null
+	,teardownAsync: null
 	,assertations: null
 	,allOk: function() {
 		var _g_head = this.assertations.h;
@@ -12499,6 +12571,119 @@ utest_ui_text_HtmlReport.prototype = {
 		buf.b += "</ul>\n";
 		buf.b += "</li>\n";
 	}
+	,getTextResults: function() {
+		var newline = "\n";
+		var indents = function(count) {
+			var _g = [];
+			var _g2 = 0;
+			while(_g2 < count) {
+				++_g2;
+				_g.push("  ");
+			}
+			return _g.join("");
+		};
+		var dumpStack = function(stack) {
+			if(stack.length == 0) {
+				return "";
+			}
+			var parts = haxe_CallStack.toString(stack).split("\n");
+			var r = [];
+			var _g1 = 0;
+			while(_g1 < parts.length) {
+				var part = parts[_g1];
+				++_g1;
+				if(part.indexOf(" utest.") >= 0) {
+					continue;
+				}
+				r.push(part);
+			}
+			return r.join(newline);
+		};
+		var buf_b = "";
+		var _g3 = 0;
+		var _g11 = this.result.packageNames();
+		while(_g3 < _g11.length) {
+			var pname = _g11[_g3];
+			++_g3;
+			var pack = this.result.getPackage(pname);
+			if(utest_ui_common_ReportTools.skipResult(this,pack.stats,this.result.stats.isOk)) {
+				continue;
+			}
+			var _g21 = 0;
+			var _g31 = pack.classNames();
+			while(_g21 < _g31.length) {
+				var cname = _g31[_g21];
+				++_g21;
+				var cls = pack.getClass(cname);
+				if(utest_ui_common_ReportTools.skipResult(this,cls.stats,this.result.stats.isOk)) {
+					continue;
+				}
+				buf_b += Std.string((pname == ""?"":pname + ".") + cname + newline);
+				var _g4 = 0;
+				var _g5 = cls.methodNames();
+				while(_g4 < _g5.length) {
+					var mname = _g5[_g4];
+					++_g4;
+					var fix = cls.get(mname);
+					if(utest_ui_common_ReportTools.skipResult(this,fix.stats,this.result.stats.isOk)) {
+						continue;
+					}
+					buf_b += Std.string(indents(1) + mname + ": ");
+					if(fix.stats.isOk) {
+						buf_b += "OK ";
+					} else if(fix.stats.hasErrors) {
+						buf_b += "ERROR ";
+					} else if(fix.stats.hasFailures) {
+						buf_b += "FAILURE ";
+					} else if(fix.stats.hasWarnings) {
+						buf_b += "WARNING ";
+					}
+					var messages = "";
+					var _g6 = fix.iterator();
+					while(_g6.head != null) {
+						var val = _g6.head.item;
+						_g6.head = _g6.head.next;
+						switch(val[1]) {
+						case 0:
+							buf_b += ".";
+							break;
+						case 1:
+							buf_b += "F";
+							messages += indents(2) + "line: " + val[3].lineNumber + ", " + val[2] + newline;
+							break;
+						case 2:
+							buf_b += "E";
+							messages += indents(2) + Std.string(val[2]) + dumpStack(val[3]) + newline;
+							break;
+						case 3:
+							buf_b += "S";
+							messages += indents(2) + Std.string(val[2]) + dumpStack(val[3]) + newline;
+							break;
+						case 4:
+							buf_b += "T";
+							messages += indents(2) + Std.string(val[2]) + dumpStack(val[3]) + newline;
+							break;
+						case 5:
+							buf_b += "O";
+							messages += indents(2) + "missed async calls: " + val[2] + dumpStack(val[3]) + newline;
+							break;
+						case 6:
+							buf_b += "A";
+							messages += indents(2) + Std.string(val[2]) + dumpStack(val[3]) + newline;
+							break;
+						case 7:
+							buf_b += "W";
+							messages += indents(2) + val[2] + newline;
+							break;
+						}
+					}
+					buf_b += newline == null?"null":"" + newline;
+					buf_b += messages == null?"null":"" + messages;
+				}
+			}
+		}
+		return buf_b;
+	}
 	,getHeader: function() {
 		var buf = new StringBuf();
 		if(!utest_ui_common_ReportTools.hasHeader(this,this.result.stats)) {
@@ -12575,6 +12760,10 @@ utest_ui_text_HtmlReport.prototype = {
 		this.result = result;
 		this.handler(this);
 		this.restoreTrace();
+		var exposedResult = { isOk : result.stats.isOk, message : this.getTextResults()};
+		if('undefined' != typeof window) {
+			window.utest_result = exposedResult;
+		}
 	}
 	,formatTime: function(t) {
 		return Math.round(t * 1000) + " ms";


### PR DESCRIPTION
Don't merge this yet, but I'm working on a fix for #5.

Part of the problem was that we were assuming that `fixedTop + 1` and `fixedBottom - 1` were different rows. The easiest way to avoid this problem is to just iterate over all of the rows and filter out the ones we don't care about. Are we worried about the speed implications of this complete `for` loop with in `if` at the top of it?
